### PR TITLE
Allow for arbitrary columns in wysiwyg layouts

### DIFF
--- a/parts/layouts/layout-wysiwygs.php
+++ b/parts/layouts/layout-wysiwygs.php
@@ -15,7 +15,8 @@
       } else {
         $offset = null;
       }
-      scratch_layout_declare(get_sub_field('wysiwygs'), 2, $offset);
+      $sub_field_count = count( (get_sub_field('wysiwygs') ) );
+      scratch_layout_declare(get_sub_field('wysiwygs'), $sub_field_count, $offset);
       while(has_sub_field('wysiwygs')) {
         scratch_layout_start();
           the_sub_field('wysiwyg');


### PR DESCRIPTION
I'm honestly still not 100% sure what the 1:2 or 2:1 layouts do, but this makes it so an arbitrary number of columns are rendered, as seems to be intended.